### PR TITLE
[Bugfix] Bad nitrite commit in go.mod 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/blocky/nitriding
 go 1.19
 
 require (
-	github.com/blocky/nitrite v0.0.2-0.20230126192142-5515b10e6983
+	github.com/blocky/nitrite v0.0.2-0.20230203005949-9ba075fecde3
 	github.com/blocky/parlor v1.0.1-0.20230104152939-e2762a403737
 	github.com/brave/viproxy v0.1.2
 	github.com/fxamacker/cbor/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/blocky/nitrite v0.0.2-0.20230126192142-5515b10e6983 h1:HXS9rrJALYH5hEwe04x3Id8Q8ySHksudx9mP+RTBa6c=
-github.com/blocky/nitrite v0.0.2-0.20230126192142-5515b10e6983/go.mod h1:QhpIeDjO6C7k9XQy6osO+Ulj+3ZwJrTfZgzW2yysOhk=
+github.com/blocky/nitrite v0.0.2-0.20230203005949-9ba075fecde3 h1:0XZYIw4O1eHu/DyEwznq5ycR2vNePWBaz2tFFORvpPM=
+github.com/blocky/nitrite v0.0.2-0.20230203005949-9ba075fecde3/go.mod h1:QhpIeDjO6C7k9XQy6osO+Ulj+3ZwJrTfZgzW2yysOhk=
 github.com/blocky/parlor v1.0.1-0.20230104152939-e2762a403737 h1:qXEyFyZ6ROB0N6CAhINTTbm12UrBiioo7oOPEUzx1yk=
 github.com/blocky/parlor v1.0.1-0.20230104152939-e2762a403737/go.mod h1:Xf/srxw38gl4j3lxo4hxpoSDociIaVWbuZi1lJhjOAk=
 github.com/brave/viproxy v0.1.2 h1:sOY8bI1CqLNq+KyRJrEzQuWia81UmLjK5kqTqD284hs=


### PR DESCRIPTION
# Issue
There is a commit for github.com/blocky/nitrite in the go.mod that does not exist (5515b10e6983)

This bad commit is not a part of the history in nitrite, and was somehow pushed into the repo

This is causing projects importing nitriding to have the error message:
```
ian@Darci-V3:[zpr](feature/zigzag-zero-api)zpr/$ go get -u github.com/blocky/nitriding@v1.0.1-0.20230203224018-176efb027136
go: github.com/blocky/nitrite@v0.0.2-0.20230126192142-5515b10e6983: invalid version: unknown revision 5515b10e6983
```

and therefore not letting me use the most up-to-date API that i need